### PR TITLE
[INFRA-1760] - Add ‘jep’, ’jira’ and ‘security’ Asciidoc macros for jenkins.io

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -121,6 +121,9 @@ javadoc:java.io.File#pathSeparator[the path separator]
 staplerdoc:org.kohsuke.stapler.AncestorInPath[]
 ----
 
+=== Other macros (jep/jira/security)
+
+See [examples](./examples).
 
 == Development
 

--- a/examples/jep.adoc
+++ b/examples/jep.adoc
@@ -1,6 +1,6 @@
 = jep macro
 
-The `jep` inline macro can be used to link to plugins on the plugins index
+The `jep` inline macro can be used to link to Jenkins Enhancement Proposals
 at https://github.com/jenkinsci/jep/tree/master/jep.
 
 ### Example 1

--- a/examples/jep.adoc
+++ b/examples/jep.adoc
@@ -1,0 +1,29 @@
+= jep macro
+
+The `jep` inline macro can be used to link to plugins on the plugins index
+at https://github.com/jenkinsci/jep/tree/master/jep.
+
+### Example 1
+
+jep:201[Jenkins Configuration as Code]
+
+Source:
+
+```
+jep:201[Jenkins Configuration as Code]
+```
+
+Result: link:https://github.com/jenkinsci/jep/blob/master/jep/201/README.adoc[JEP-201: Jenkins Configuration as Code]
+
+### Example 2
+
+jep:201[]
+
+Source:
+
+```
+jep:201[]
+```
+
+Result: link:https://github.com/jenkinsci/jep/blob/master/jep/201/README.adoc[JEP-201]
+

--- a/examples/jira.adoc
+++ b/examples/jira.adoc
@@ -1,0 +1,40 @@
+= jira macro
+
+The `jira` inline macro can be used to link to plugins on the plugins index
+at http://issues.jenkins-ci.org/.
+
+### Example 1. Referencing JENKINS project
+
+jira:38313[Jenkins Configuration as Code]
+
+Source:
+
+```
+jira:38313[Jenkins Configuration as Code]
+```
+
+Result: link:https://issues.jenkins-ci.org/browse/JENKINS-38313[JENKINS-38313: External Build Log storage for Jenkins]
+
+### Example 2. Referencing non-JENKINS projects
+
+jira:INFRA-1760[Create "jep" and "jira" macros for jenkins.io]
+
+Source:
+
+```
+jira:INFRA-1760[Create "jep" and "jira" macros for jenkins.io]
+```
+
+Result: link:https://issues.jenkins-ci.org/browse/INFRA-1760[INFRA-1760: Create "jep" and "jira" macros for jenkins.io]
+
+### Example 3. Reference without text
+
+jira:38313[]
+
+Source:
+
+```
+jira:38313[]
+```
+
+Result: link:https://issues.jenkins-ci.org/browse/JENKINS-38313[JENKINS-38313]

--- a/examples/security.adoc
+++ b/examples/security.adoc
@@ -1,0 +1,35 @@
+= security macro
+
+The `security` inline macro can be used to reference security fixes
+in Jenkins Security advisories: https://jenkins.io/security/advisories/.
+
+### Example 1. Referencing SECURITY issues
+
+The macro also allows referencing SECURITY issues.
+These issues are not public, so an advisory is linked instead.
+Currently it requires issueDate to be specified as a second macro argument.
+
+security:637["Jenkins allowed deserialization of URL objects with host components", "2018-08-15"]
+
+Source:
+
+```
+security:637["Jenkins allowed deserialization of URL objects with host components", "2018-08-15"]
+```
+
+Result: link:https://jenkins.io/security/advisory/2018-08-15/#SECURITY-637[SECURITY-637: Jenkins allowed deserialization of URL objects with host components]
+
+### Example 2. Referencing SECURITY issues without text
+
+The macro also allows referencing
+
+security:1076[date="2018-08-15"]
+
+Source:
+
+```
+security:1076[date="2018-08-15"]
+```
+
+Result: link:https://jenkins.io/security/advisory/2018-08-15/#SECURITY-1076[SECURITY-1076]
+

--- a/lib/asciidoctor/jenkins/extensions/jep-link.rb
+++ b/lib/asciidoctor/jenkins/extensions/jep-link.rb
@@ -1,0 +1,23 @@
+require 'asciidoctor'
+require 'asciidoctor/extensions'
+
+#
+# Usage:
+# jep:201[Jenkins Configuration as Code]
+#
+Asciidoctor::Extensions.register do
+  inline_macro do
+    named :jep
+    name_positional_attributes 'label'
+
+    process do |parent, target, attrs|
+      if attrs['label']
+        label = %(JEP-#{target}: #{attrs['label']})
+      else
+        label = %(JEP-#{target})
+      end
+      target = %(https://github.com/jenkinsci/jep/blob/master/jep/#{target}/README.adoc)
+      (create_anchor parent, label, type: :link, target: target).render
+    end
+  end
+end

--- a/lib/asciidoctor/jenkins/extensions/jira-link.rb
+++ b/lib/asciidoctor/jenkins/extensions/jira-link.rb
@@ -1,0 +1,30 @@
+require 'asciidoctor'
+require 'asciidoctor/extensions'
+
+#
+# Usage:
+# jira:JENKINS-12345[Issue description]
+#
+Asciidoctor::Extensions.register do
+  inline_macro do
+    named :jira
+    name_positional_attributes 'label'
+
+    process do |parent, target, attrs|
+      if target.include? "-"
+        issueId = target
+      else
+        issueId = %(JENKINS-#{target})
+      end
+
+      if attrs['label']
+        label = %(#{issueId}: #{attrs['label']})
+      else
+        label = issueId
+      end
+
+      target = %(https://issues.jenkins-ci.org/browse/#{target})
+      (create_anchor parent, label, type: :link, target: target).render
+    end
+  end
+end

--- a/lib/asciidoctor/jenkins/extensions/security-link.rb
+++ b/lib/asciidoctor/jenkins/extensions/security-link.rb
@@ -3,7 +3,7 @@ require 'asciidoctor/extensions'
 
 #
 # Usage:
-# security:12345[Issue description]
+# security:12345[Issue description, date]
 #
 Asciidoctor::Extensions.register do
   inline_macro do

--- a/lib/asciidoctor/jenkins/extensions/security-link.rb
+++ b/lib/asciidoctor/jenkins/extensions/security-link.rb
@@ -1,0 +1,36 @@
+require 'asciidoctor'
+require 'asciidoctor/extensions'
+
+#
+# Usage:
+# security:12345[Issue description]
+#
+Asciidoctor::Extensions.register do
+  inline_macro do
+    named :security
+    name_positional_attributes 'label', 'date'
+
+    process do |parent, target, attrs|
+      if target.include? "-"
+        issueId = target
+      else
+        issueId = %(SECURITY-#{target})
+      end
+
+      if attrs['label']
+        label = %(#{issueId}: #{attrs['label']})
+      else
+        label = issueId
+      end
+
+    if attrs['date']
+        target = %(https://jenkins.io/security/advisory/#{attrs['date']}/##{issueId})
+    else
+        # TODO(oleg_nenashev): Change to a security issue redirect service if it gets created
+        target = %(https://jenkins.io/security/advisories/)
+    end
+
+      (create_anchor parent, label, type: :link, target: target).render
+    end
+  end
+end


### PR DESCRIPTION
I am working on SIG page updates, which require a lot of JEP/JIRA references.
So I have decided to add macros to simplify the pages.

See README paces for examples, all examples work well in `shotgun`

https://issues.jenkins-ci.org/browse/INFRA-1760

@jenkins-infra/copy-editors, esp. @bitwiseman @rtyler @daniel-beck + @jglick and @carlossg 