### PR TITLE
[WEBSITE-523] - Fix the macro for empty ID prefix

### DIFF
--- a/lib/asciidoctor/jenkins/extensions/jira-link.rb
+++ b/lib/asciidoctor/jenkins/extensions/jira-link.rb
@@ -23,7 +23,7 @@ Asciidoctor::Extensions.register do
         label = issueId
       end
 
-      target = %(https://issues.jenkins-ci.org/browse/#{target})
+      target = %(https://issues.jenkins-ci.org/browse/#{issueId})
       (create_anchor parent, label, type: :link, target: target).render
     end
   end


### PR DESCRIPTION
@jglick @bitwiseman

https://issues.jenkins-ci.org/browse/WEBSITE-523