### PR TITLE
Require docker&&linux

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
     agent {
         docker {
             image 'ruby:2.4-alpine'
-            label 'docker'
+            label 'docker&&linux'
         }
     }
 


### PR DESCRIPTION
When Windows docker agents are available, make sure this lands on a Linux docker agent.