### PR TITLE
[Hacktoberfest] Fix fragment handling and add component support

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -90,7 +90,7 @@ plugin:git[The Git Plugin]
 
 === jenkinsdoc/staplerdoc/javadoc macros
 
-The `jenkinsdoc` inline macro can be used to link to the Jenkins Javadoc at http://javadoc.jenkins.io/.
+The `jenkinsdoc` inline macro can be used to link to the Jenkins Javadoc at https://javadoc.jenkins.io/.
 
 It supports a variety of different syntaxes. For classes in Jenkins core:
 

--- a/asciidoctor-jenkins-extensions.gemspec
+++ b/asciidoctor-jenkins-extensions.gemspec
@@ -30,7 +30,7 @@ formatting in Jenkins-related content.
   spec.add_dependency 'coderay', '~> 1.1.1'
   spec.add_dependency 'colorize', '~> 0.8.1'
 
-  spec.add_development_dependency "bundler", "~> 1.11"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "rspec-its"

--- a/examples/javadoc.adoc
+++ b/examples/javadoc.adoc
@@ -4,7 +4,7 @@
 Below are some examples of using the `jenkinsdoc`, `staplerdoc`, and `javadoc`
 macros.
 
-The `jenkinsdoc` inline macro can be used to link to the Jenkins Javadoc at http://javadoc.jenkins.io/.
+The `jenkinsdoc` inline macro can be used to link to the Jenkins Javadoc at https://javadoc.jenkins.io/.
 
 It supports a variety of different syntaxes. For classes in Jenkins core:
 
@@ -27,6 +27,13 @@ For classes in plugins, the plugin's name (`artifactId`) is put before the class
 
 * jenkinsdoc:git:hudson.plugins.git.GitSCM[] links to the full URL for the class in the git plugin.
 * jenkinsdoc:git:hudson.plugins.git.GitSCM#getRepositories--[] links to the full URL for the class in the git plugin, and includes a fragment.
+
+---
+
+For classes in components, the component's (`artifactId`) is put before the class name and separated by colon, note the `component` selector is also required:
+
+* jenkinsdoc:component:remoting:hudson.remoting.Channel[] links to the full URL for the class in the remoting component.
+* jenkinsdoc:component:remoting:hudson.remoting.Channel#classLoadingCount[] links to the full URL for the class in the remoting component, and includes a fragment.
 
 ---
 

--- a/lib/asciidoctor/jenkins/extensions/javadoc-link.rb
+++ b/lib/asciidoctor/jenkins/extensions/javadoc-link.rb
@@ -20,6 +20,14 @@ require 'asciidoctor/extensions'
 # jenkinsdoc:git:hudson.plugins.git.GitSCM[some label]
 # jenkinsdoc:git:hudson.plugins.git.GitSCM#anchor[]
 # jenkinsdoc:git:hudson.plugins.git.GitSCM#anchor[some label]
+#
+#
+# For component Javadoc:
+#
+# jenkinsdoc:component:remoting:hudson.remoting.Channel[]
+# jenkinsdoc:component:remoting:hudson.remoting.Channel[some label]
+# jenkinsdoc:component:remoting:hudson.remoting.Channel#anchor[]
+# jenkinsdoc:component:remoting:hudson.remoting.Channel#anchor[some label]
 
 Asciidoctor::Extensions.register do
   inline_macro do
@@ -29,8 +37,13 @@ Asciidoctor::Extensions.register do
     process do |parent, target, attrs|
 
       if target.include? ":"
-        parts = target.split(':', 2)
-        plugin = parts.first
+        parts = target.split(':', 3)
+
+        if parts.first == "component"
+          component = parts[1]
+        else
+          plugin = parts.first
+        end
         target = parts.last
       end
       classname = label = title = target
@@ -43,6 +56,13 @@ Asciidoctor::Extensions.register do
       classname.split('.').each do |part|
         if is_package && /[[:lower:]]/.match(part[0])
           package_parts.push(part)
+        elsif match = /(.*)#/.match(part)
+          class_part = match.captures
+          simpleclass_parts.push(class_part)
+          is_package = false
+
+          # escape once fragment has been found, required for complex fragments that contain a '.'
+          break
         else
           is_package = false
           simpleclass_parts.push(part)
@@ -52,15 +72,18 @@ Asciidoctor::Extensions.register do
       package = package_parts.join('.')
       simpleclass = simpleclass_parts.join('.')
 
-      if package.length > 0 || plugin
+      if package.length > 0 || plugin || component
         classname = classname.gsub(/#.*/, '')
         classurl = package.gsub(/\./, '/') + '/' + simpleclass + ".html"
 
-        classfrag = (target.include? "#") ? '#' + target.gsub(/.*#/, '') : ''
+        classfrag = (target.include? "#") ? '#' + target.gsub(/.*#/, '').gsub(/\(\)/, '--') : ''
 
         if plugin
           label = (attrs.has_key? 'label') ? attrs['label'] : %(#{classname} in #{plugin})
           target = %(https://javadoc.jenkins.io/plugin/#{plugin}/#{classurl}#{classfrag})
+        elsif component
+          label = (attrs.has_key? 'label') ? attrs['label'] : %(#{classname} in #{component})
+          target = %(https://javadoc.jenkins.io/component/#{component}/#{classurl}#{classfrag})
         else
           label = (attrs.has_key? 'label') ? attrs['label'] : classname
           target = %(https://javadoc.jenkins.io/#{classurl}#{classfrag})
@@ -92,8 +115,16 @@ Asciidoctor::Extensions.register do
       is_package = true
 
       classname.split('.').each do |part|
+        match = /(.*)#/.match(part)
         if is_package && /[[:lower:]]/.match(part[0])
           package_parts.push(part)
+        elsif match = /(.*)#/.match(part)
+          class_part = match.captures
+          simpleclass_parts.push(class_part)
+          is_package = false
+
+          # escape once fragment has been found, required for complex fragments that contain a '.'
+          break
         else
           is_package = false
           simpleclass_parts.push(part)
@@ -106,7 +137,7 @@ Asciidoctor::Extensions.register do
       classname = target.gsub(/#.*/, '')
       classurl = package.gsub(/\./, '/') + '/' + simpleclass + ".html"
 
-      classfrag = (target.include? "#") ? '#' + target.gsub(/.*#/, '') : ''
+      classfrag = (target.include? "#") ? '#' + target.gsub(/.*#/, '').gsub(/\(\)/, '--') : ''
       label = (attrs.has_key? 'label') ? attrs['label'] : classname
       target = %(https://stapler.kohsuke.org/apidocs/#{classurl}#{classfrag})
 
@@ -135,6 +166,13 @@ Asciidoctor::Extensions.register do
       classname.split('.').each do |part|
         if is_package && /[[:lower:]]/.match(part[0])
           package_parts.push(part)
+        elsif match = /(.*)#/.match(part)
+          class_part = match.captures
+          simpleclass_parts.push(class_part)
+          is_package = false
+
+          # escape once fragment has been found, required for complex fragments that contain a '.'
+          break
         else
           is_package = false
           simpleclass_parts.push(part)
@@ -147,7 +185,7 @@ Asciidoctor::Extensions.register do
       classname = target.gsub(/#.*/, '')
       classurl = package.gsub(/\./, '/') + '/' + simpleclass + ".html"
 
-      classfrag = (target.include? "#") ? '#' + target.gsub(/.*#/, '') : ''
+      classfrag = (target.include? "#") ? '#' + target.gsub(/.*#/, '').gsub(/\(\)/, '--') : ''
       label = (attrs.has_key? 'label') ? attrs['label'] : classname
       target = %(https://docs.oracle.com/javase/8/docs/api/#{classurl}#{classfrag})
 

--- a/lib/asciidoctor/jenkins/extensions/javadoc-link.rb
+++ b/lib/asciidoctor/jenkins/extensions/javadoc-link.rb
@@ -60,14 +60,14 @@ Asciidoctor::Extensions.register do
 
         if plugin
           label = (attrs.has_key? 'label') ? attrs['label'] : %(#{classname} in #{plugin})
-          target = %(http://javadoc.jenkins.io/plugin/#{plugin}/#{classurl}#{classfrag})
+          target = %(https://javadoc.jenkins.io/plugin/#{plugin}/#{classurl}#{classfrag})
         else
           label = (attrs.has_key? 'label') ? attrs['label'] : classname
-          target = %(http://javadoc.jenkins.io/#{classurl}#{classfrag})
+          target = %(https://javadoc.jenkins.io/#{classurl}#{classfrag})
         end
       else
         label = (attrs.has_key? 'label') ? attrs['label'] : classname
-        target = %(http://javadoc.jenkins.io/byShortName/#{classname})
+        target = %(https://javadoc.jenkins.io/byShortName/#{classname})
       end
 
       title = %(Javadoc for #{classname})
@@ -108,7 +108,7 @@ Asciidoctor::Extensions.register do
 
       classfrag = (target.include? "#") ? '#' + target.gsub(/.*#/, '') : ''
       label = (attrs.has_key? 'label') ? attrs['label'] : classname
-      target = %(http://stapler.kohsuke.org/apidocs/#{classurl}#{classfrag})
+      target = %(https://stapler.kohsuke.org/apidocs/#{classurl}#{classfrag})
 
       title = %(Javadoc for #{classname})
 
@@ -149,7 +149,7 @@ Asciidoctor::Extensions.register do
 
       classfrag = (target.include? "#") ? '#' + target.gsub(/.*#/, '') : ''
       label = (attrs.has_key? 'label') ? attrs['label'] : classname
-      target = %(http://docs.oracle.com/javase/7/docs/api/#{classurl}#{classfrag})
+      target = %(https://docs.oracle.com/javase/8/docs/api/#{classurl}#{classfrag})
 
       title = %(Javadoc for #{classname})
 

--- a/lib/asciidoctor/jenkins/extensions/version.rb
+++ b/lib/asciidoctor/jenkins/extensions/version.rb
@@ -1,7 +1,7 @@
 module Asciidoctor
   module Jenkins
     module Extensions
-      VERSION = "0.5.1"
+      VERSION = "0.6.0"
     end
   end
 end

--- a/spec/javadoc_spec.rb
+++ b/spec/javadoc_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+require 'asciidoctor'
+require 'asciidoctor/jenkins/extensions'
+
+describe 'the javadoc macro' do
+    subject(:rendering) { Asciidoctor.render(document) }
+
+    context 'with a simple document' do
+        let(:document) {
+            "javadoc:java.nio.file.DirectoryStream.Filter[]"
+        }
+
+        it 'should render properly' do
+            expect(rendering).to match(/https:\/\/docs.oracle.com\/javase\/8\/docs\/api\/java\/nio\/file\/DirectoryStream.Filter.html.+>java.nio.file.DirectoryStream.Filter/)
+        end
+    end
+
+    context 'with label' do
+        let(:document) {
+            "javadoc:java.io.File[file]"
+        }
+
+        it 'should render properly' do
+            expect(rendering).to match(/https:\/\/docs.oracle.com\/javase\/8\/docs\/api\/java\/io\/File.html.+>file/)
+        end
+    end
+
+    context 'with a fragment' do
+        let(:document) {
+            "javadoc:java.io.File#pathSeparator[]"
+        }
+
+        it 'should render properly' do
+            expect(rendering).to match(/https:\/\/docs.oracle.com\/javase\/8\/docs\/api\/java\/io\/File.html#pathSeparator.+>java.io.File/)
+        end
+    end
+end

--- a/spec/jenkinsdoc_spec.rb
+++ b/spec/jenkinsdoc_spec.rb
@@ -1,0 +1,85 @@
+require 'spec_helper'
+
+require 'asciidoctor'
+require 'asciidoctor/jenkins/extensions'
+
+describe 'the jenkinsdoc macro' do
+    subject(:rendering) { Asciidoctor.render(document) }
+
+    context 'with a simple document' do
+        let(:document) {
+            "jenkinsdoc:hudson.scm.SCM[]"
+        }
+
+        it 'should render properly' do
+            expect(rendering).to match(/https:\/\/javadoc.jenkins.io\/hudson\/scm\/SCM.html.+>hudson.scm.SCM/)
+        end
+    end
+
+    context 'with label' do
+        let(:document) {
+            "jenkinsdoc:hudson.scm.SCM[a list of all known SCM implementations]"
+        }
+
+        it 'should render properly' do
+            expect(rendering).to match(/https:\/\/javadoc.jenkins.io\/hudson\/scm\/SCM.html.+>a list of all known SCM implementations/)
+        end
+    end
+
+    context 'with a fragment' do
+        let(:document) {
+            "jenkinsdoc:hudson.scm.SCM#all()[]"
+        }
+
+        it 'should render properly' do
+            expect(rendering).to match(/https:\/\/javadoc.jenkins.io\/hudson\/scm\/SCM.html#all--.+>hudson.scm.SCM/)
+        end
+    end
+
+    context 'with a short name' do
+        let(:document) {
+            "jenkinsdoc:SCM[]"
+        }
+
+        it 'should render properly' do
+            expect(rendering).to match(/https:\/\/javadoc.jenkins.io\/byShortName\/SCM.+>SCM/)
+        end
+    end
+
+    context 'with a plugin' do
+        let(:document) {
+            "jenkinsdoc:git:hudson.plugins.git.GitSCM[]"
+        }
+        it 'should render properly' do
+            expect(rendering).to match(/https:\/\/javadoc.jenkins.io\/plugin\/git\/hudson\/plugins\/git\/GitSCM.html.+>hudson.plugins.git.GitSCM/)
+        end
+    end
+
+    context 'with a plugin and a fragment' do
+        let(:document) {
+            "jenkinsdoc:git:hudson.plugins.git.GitSCM#getRepositories()[]"
+        }
+        it 'should render properly' do
+            expect(rendering).to match(/https:\/\/javadoc.jenkins.io\/plugin\/git\/hudson\/plugins\/git\/GitSCM.html#getRepositories--.+>hudson.plugins.git.GitSCM/)
+        end
+    end
+
+    context 'with a component' do
+        let(:document) {
+            "jenkinsdoc:component:remoting:hudson.remoting.Channel[]"
+        }
+        it 'should render properly' do
+            expect(rendering).to match(/https:\/\/javadoc.jenkins.io\/component\/remoting\/hudson\/remoting\/Channel.html.+>hudson.remoting.Channel/)
+        end
+    end
+
+    context 'with a component and a fragment' do
+        let(:document) {
+            "jenkinsdoc:component:remoting:hudson.remoting.Channel#classLoadingCount[]"
+        }
+        it 'should render properly' do
+            expect(rendering).to match(/https:\/\/javadoc.jenkins.io\/component\/remoting\/hudson\/remoting\/Channel.html#classLoadingCount.+>hudson.remoting.Channel/)
+        end
+    end
+
+end

--- a/spec/staplerdoc_spec.rb
+++ b/spec/staplerdoc_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+require 'asciidoctor'
+require 'asciidoctor/jenkins/extensions'
+
+describe 'the staplerdoc macro' do
+    subject(:rendering) { Asciidoctor.render(document) }
+
+    context 'with a simple document' do
+        let(:document) {
+            "staplerdoc:org.kohsuke.stapler.AncestorInPath[]"
+        }
+
+        it 'should render properly' do
+            expect(rendering).to match(/https:\/\/stapler.kohsuke.org\/apidocs\/org\/kohsuke\/stapler\/AncestorInPath.html.+>org.kohsuke.stapler.AncestorInPath/)
+        end
+    end
+
+    context 'with label' do
+        let(:document) {
+            "staplerdoc:org.kohsuke.stapler.AncestorInPath[a label]"
+        }
+
+        it 'should render properly' do
+            expect(rendering).to match(/https:\/\/stapler.kohsuke.org\/apidocs\/org\/kohsuke\/stapler\/AncestorInPath.html.+>a label/)
+        end
+    end
+
+    context 'with a fragment' do
+        let(:document) {
+            "staplerdoc:org.kohsuke.stapler.WebMethodContext#getName()[]"
+        }
+
+        it 'should render properly' do
+            expect(rendering).to match(/https:\/\/stapler.kohsuke.org\/apidocs\/org\/kohsuke\/stapler\/WebMethodContext.html#getName--.+>org.kohsuke.stapler.WebMethodContext/)
+        end
+    end
+
+    context 'with a complex fragment' do
+        let(:document) {
+            "staplerdoc:org.kohsuke.stapler.ReflectionUtils#union-java.lang.annotation.Annotation:A-java.lang.annotation.Annotation:A-[]"
+        }
+
+        it 'should render properly' do
+            expect(rendering).to match(/https:\/\/stapler.kohsuke.org\/apidocs\/org\/kohsuke\/stapler\/ReflectionUtils.html#union-java.lang.annotation.Annotation:A-java.lang.annotation.Annotation:A-.+>org.kohsuke.stapler.ReflectionUtils/)
+        end
+    end
+end


### PR DESCRIPTION
Regression in:
https://github.com/jenkins-infra/asciidoctor-jenkins-extensions/pull/1
It broke fragment handling

Implemented [WEBSITE-464](https://issues.jenkins-ci.org/browse/WEBSITE-464) while I was here

For background see discussion in:
https://github.com/jenkins-infra/jenkins.io/pull/2584#discussion_r336773390

This repo seemed a bit light on tests so I've added pretty good coverage.

Also changed all generated links from http to https and updated `javadoc` to use java 8

cc @rtyler @daniel-beck  @oleg-nenashev