### PR TITLE
Update staplerdoc macro

### DIFF
--- a/lib/asciidoctor/jenkins/extensions/javadoc-link.rb
+++ b/lib/asciidoctor/jenkins/extensions/javadoc-link.rb
@@ -139,7 +139,7 @@ Asciidoctor::Extensions.register do
 
       classfrag = (target.include? "#") ? '#' + target.gsub(/.*#/, '').gsub(/\(\)/, '--') : ''
       label = (attrs.has_key? 'label') ? attrs['label'] : classname
-      target = %(https://stapler.kohsuke.org/apidocs/#{classurl}#{classfrag})
+      target = %(https://javadoc.jenkins.io/component/stapler/#{classurl}#{classfrag})
 
       title = %(Javadoc for #{classname})
 

--- a/lib/asciidoctor/jenkins/extensions/version.rb
+++ b/lib/asciidoctor/jenkins/extensions/version.rb
@@ -1,7 +1,7 @@
 module Asciidoctor
   module Jenkins
     module Extensions
-      VERSION = "0.8.0"
+      VERSION = "0.9.0"
     end
   end
 end

--- a/spec/staplerdoc_spec.rb
+++ b/spec/staplerdoc_spec.rb
@@ -12,7 +12,7 @@ describe 'the staplerdoc macro' do
         }
 
         it 'should render properly' do
-            expect(rendering).to match(/https:\/\/stapler.kohsuke.org\/apidocs\/org\/kohsuke\/stapler\/AncestorInPath.html.+>org.kohsuke.stapler.AncestorInPath/)
+            expect(rendering).to match(/https:\/\/javadoc.jenkins.io\/component\/stapler\/org\/kohsuke\/stapler\/AncestorInPath.html.+>org.kohsuke.stapler.AncestorInPath/)
         end
     end
 
@@ -22,7 +22,7 @@ describe 'the staplerdoc macro' do
         }
 
         it 'should render properly' do
-            expect(rendering).to match(/https:\/\/stapler.kohsuke.org\/apidocs\/org\/kohsuke\/stapler\/AncestorInPath.html.+>a label/)
+            expect(rendering).to match(/https:\/\/javadoc.jenkins.io\/component\/stapler\/org\/kohsuke\/stapler\/AncestorInPath.html.+>a label/)
         end
     end
 
@@ -32,7 +32,7 @@ describe 'the staplerdoc macro' do
         }
 
         it 'should render properly' do
-            expect(rendering).to match(/https:\/\/stapler.kohsuke.org\/apidocs\/org\/kohsuke\/stapler\/WebMethodContext.html#getName--.+>org.kohsuke.stapler.WebMethodContext/)
+            expect(rendering).to match(/https:\/\/javadoc.jenkins.io\/component\/stapler\/org\/kohsuke\/stapler\/WebMethodContext.html#getName--.+>org.kohsuke.stapler.WebMethodContext/)
         end
     end
 
@@ -42,7 +42,7 @@ describe 'the staplerdoc macro' do
         }
 
         it 'should render properly' do
-            expect(rendering).to match(/https:\/\/stapler.kohsuke.org\/apidocs\/org\/kohsuke\/stapler\/ReflectionUtils.html#union-java.lang.annotation.Annotation:A-java.lang.annotation.Annotation:A-.+>org.kohsuke.stapler.ReflectionUtils/)
+            expect(rendering).to match(/https:\/\/javadoc.jenkins.io\/component\/stapler\/org\/kohsuke\/stapler\/ReflectionUtils.html#union-java.lang.annotation.Annotation:A-java.lang.annotation.Annotation:A-.+>org.kohsuke.stapler.ReflectionUtils/)
         end
     end
 end


### PR DESCRIPTION
## Update staplerdoc location

The stapler javadoc has moved from https://stapler.kohsuke.org/apidocs/ to https://javadoc.jenkins.io/component/stapler/ .  This updates the staplerdoc macro to point to the new location.

First step towards a fix for https://github.com/jenkins-infra/jenkins.io/issues/4410
