### PR TITLE
chore(documentation): replace npm install with npm ci

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -53,7 +53,7 @@ node {
     stage('Build') {
       checkout scm
       // Install dependencies
-      sh 'npm install'
+      sh 'npm ci'
     }
 }
 
@@ -62,7 +62,7 @@ pipeline {
     agent docker: 'node:6.3'
     stages {
         stage('Build') {
-            sh 'npm install'
+            sh 'npm ci'
         }
     }
 }

--- a/examples/pipeline.adoc
+++ b/examples/pipeline.adoc
@@ -12,7 +12,7 @@ node {
     stage('Build') {
       checkout scm
       // Install dependencies
-      sh 'npm install'
+      sh 'npm ci'
     }
 }
 
@@ -21,7 +21,7 @@ pipeline {
     agent docker: 'node:6.3'
     stages {
         stage('Build') {
-            sh 'npm install'
+            sh 'npm ci'
         }
     }
 }
@@ -38,7 +38,7 @@ node {
     stage('Build') {
       checkout scm
       // Install dependencies
-      sh 'npm install'
+      sh 'npm ci'
     }
 }
 ----
@@ -52,7 +52,7 @@ pipeline {
     agent docker: 'node:6.3'
     stages {
         stage('Build') {
-            sh 'npm install'
+            sh 'npm ci'
         }
     }
 }


### PR DESCRIPTION
Ref:

- https://github.com/jenkins-infra/helpdesk/issues/5119

enforcing npm ci over npm install across CI/CD pipelines for reproducible builds.

- `README.adoc` and `examples/pipeline.adoc`: Updated install instructions to use `npm ci`